### PR TITLE
Related to Fixing errors with _obtain_steps function #27

### DIFF
--- a/scope_rl/dataset/synthetic.py
+++ b/scope_rl/dataset/synthetic.py
@@ -720,7 +720,7 @@ class SyntheticDataset(BaseDataset):
             if not obtain_trajectories_from_single_interaction:
                 done = True
 
-                for rollout_step in rollout_lengths[i]:
+                for rollout_step in range(rollout_lengths[i]):
                     if done:
                         state, info_ = self.env.reset()
                         step = 0

--- a/scope_rl/dataset/synthetic.py
+++ b/scope_rl/dataset/synthetic.py
@@ -691,10 +691,10 @@ class SyntheticDataset(BaseDataset):
             actions = np.zeros(n_trajectories * step_per_trajectory, dtype=int)
             action_probs = np.zeros(n_trajectories * step_per_trajectory, dtype=int)
         else:
-            actions = np.zeros(n_trajectories * step_per_trajectory, self.action_dim)
-            action_probs = np.zeros(
+            actions = np.zeros((n_trajectories * step_per_trajectory, self.action_dim))
+            action_probs = np.zeros((
                 n_trajectories * step_per_trajectory, self.action_dim
-            )
+            ))
 
         rewards = np.zeros(n_trajectories * step_per_trajectory)
         dones = np.zeros(n_trajectories * step_per_trajectory)

--- a/scope_rl/dataset/synthetic.py
+++ b/scope_rl/dataset/synthetic.py
@@ -750,7 +750,7 @@ class SyntheticDataset(BaseDataset):
                 (
                     action,
                     action_prob,
-                ) = self.behavior_policy.sample_action_and_output_pscore_online(state)
+                ) = behavior_policy.sample_action_and_output_pscore_online(state)
                 next_state, reward, done, truncated, info_ = self.env.step(action)
 
                 states[idx] = state

--- a/scope_rl/dataset/synthetic.py
+++ b/scope_rl/dataset/synthetic.py
@@ -709,7 +709,7 @@ class SyntheticDataset(BaseDataset):
         idx, step = 0, 0
         done = False
         state, info_ = self.env.reset()
-
+        next_state = None
         for i in tqdm(
             np.arange(n_trajectories),
             desc="[obtain_trajectories]",
@@ -1268,7 +1268,6 @@ class SyntheticDataset(BaseDataset):
                 path=path,
                 save_relative_path=save_relative_path,
             )
-
             for j in tqdm(
                 np.arange(len(behavior_policies)),
                 desc="[obtain_datasets: behavior_policy]",


### PR DESCRIPTION
## Type of change
- [x] Bugfix

## Description

**First change** - Fix a TypeError caused by an unenumerable object

- _What has been changed?_:  The TypeError caused by an unenumerable object when using a for loop with rollout_lengths[i] has been fixed. Instead of directly accessing rollout_lengths[i], the fix involves iterating directly over the range of rollout_lengths[i].

- _How the logic works?_: The previous implementation attempted to use rollout_lengths[i] directly in a loop, which caused a TypeError due to rollout_lengths being an unenumerable object created with self.random_.choice(), resulting in a numpy.int32 object. The fix involves iterating over the range of rollout_lengths[i], ensuring that each step of the loop corresponds to an index within the range of rollout_lengths[i], thus avoiding the TypeError.

**Second change** - Fixed form params in np.zeros for action arrays : 

- The shape argument in np.zeros calls for 'actions' and 'action_probs' arrays has been corrected from one-dimensional to tuple format. 
- This change ensures that the arrays are correctly initialized with the intended dimensions (n_trajectories * step_per_trajectory, action_dim), which is the expected structure for processing action data.  provide me with this format

## References
- [Fixing errors with _obtain_steps function #27](https://github.com/hakuhodo-technologies/scope-rl/issues/27)

## Checklist
- [x] pass unit test (or unnecessary)
- [x] no errors on newly made test cases
- [x] no errors on existing test cases
- [ ] applied black formatter
- [ ] No errors on flake8
- [x] no warnings

## Comments

-  Error with flake8: There is another error with flake, but I did not fix it because it was related to MultipleLoggedDataset, which I have not try to train yet (I left it for future work) - synthetic.py:1290:25: F821 undefined name 'logged_dataset_'

 - **_black format removes the () for the np.zero_**: I suspect that the wrong dimensions are due to the Black format. When I apply Black to synthetic.py, for some reason it removes the () in the lines, which I have already corrected. I assume Black was applied throughout the directory, so the changes were just picked up. Be aware of this 💯  
